### PR TITLE
fix: Fix link to contributor docs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 - [ ] Ready for review
-- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk-paket-parser/blob/master/CONTRIBUTING.md) rules
+- [ ] Follows [CONTRIBUTING](CONTRIBUTING.md) rules
 - [ ] Reviewed by Snyk internal team
 
  #### What does this PR do?


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk-paket-parser/blob/master/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

 #### What does this PR do?

Fix the link to Contributor docs in PR template