### PR TITLE
fix: remove lodash

### DIFF
--- a/lib/dependencies-parser.ts
+++ b/lib/dependencies-parser.ts
@@ -1,5 +1,4 @@
-import {startsWith} from 'lodash';
-import {Line, parseLines} from './line-parser';
+import {parseLines} from './line-parser';
 
 const COMMENTS = ['#', '//'];
 const GROUP = 'group';
@@ -138,14 +137,14 @@ export function parseDependenciesFile(input: string): PaketDependencies {
   };
 
   for (const line of lines) {
-    const isComment = !!COMMENTS.find((comment) => startsWith(line.data, comment));
+    const isComment = !!COMMENTS.find((comment) => line.data.startsWith(comment));
 
     // Ignore commented lines.
     if (isComment) {
       continue;
     }
 
-    if (startsWith(line.data, `${GROUP} `)) {
+    if (line.data.startsWith(`${GROUP} `)) {
       result.push(group);
       group = {
         dependencies: [],
@@ -153,19 +152,19 @@ export function parseDependenciesFile(input: string): PaketDependencies {
         options: {},
         sources: [],
       };
-    } else if (startsWith(line.data, `${SOURCE} `)) {
+    } else if (line.data.startsWith(`${SOURCE} `)) {
       group.sources.push(parseSource(line.data));
-    } else if (startsWith(line.data, `${GITHUB} `)) {
+    } else if (line.data.startsWith(`${GITHUB} `)) {
       group.dependencies.push(parseGithub(line.data));
-    } else if (startsWith(line.data, `${NUGET} `)) {
+    } else if (line.data.startsWith(`${NUGET} `)) {
       group.dependencies.push(parseNuget(line.data));
-    } else if (startsWith(line.data, `${CLITOOL} `)) {
+    } else if (line.data.startsWith(`${CLITOOL} `)) {
       // TODO
-    } else if (startsWith(line.data, `${GIT} `)) {
+    } else if (line.data.startsWith(`${GIT} `)) {
       // TODO
-    } else if (startsWith(line.data, `${GIST} `)) {
+    } else if (line.data.startsWith(`${GIST} `)) {
       // TODO
-    } else if (startsWith(line.data, `${HTTP} `)) {
+    } else if (line.data.startsWith(`${HTTP} `)) {
       // TODO
     } else {
       const [name, value] = parseGroupOption(line.data);

--- a/lib/lock-parser.ts
+++ b/lib/lock-parser.ts
@@ -1,4 +1,3 @@
-import {startsWith} from 'lodash';
 import {Line, parseLines} from './line-parser';
 
 const REPOSITORY_TYPES = ['HTTP', 'GIST', 'GIT', 'NUGET', 'GITHUB']; // naming convention in paket's standard parser
@@ -96,7 +95,7 @@ export function parseLockFile(input: string): PaketLock {
     const upperCaseLine = line.data.toUpperCase();
 
     if (line.indentation === 0) { // group or group option
-      if (startsWith(upperCaseLine, GROUP)) {
+      if (upperCaseLine.startsWith(GROUP)) {
         result.groups.push(group);
         depContext = {};
         group = {
@@ -115,13 +114,13 @@ export function parseLockFile(input: string): PaketLock {
         group.options[optionName.trim()] = optionValue ? optionValue.trim() : null;
       }
     } else if (line.indentation === 1) { // remote or specs
-      if (startsWith(upperCaseLine, REMOTE)) {
+      if (upperCaseLine.startsWith(REMOTE)) {
         const remote = line.data.substring(REMOTE.length + ':'.length).trim();
         if (remote) {
           depContext.remote = remote;
           group.repositories[depContext.repository].push(remote);
         }
-      } else if (startsWith(upperCaseLine, SPECS)) {
+      } else if (upperCaseLine.startsWith(SPECS)) {
         // TODO: for now we add the specs as boolean in meta
         group.specs = true;
       }

--- a/package.json
+++ b/package.json
@@ -25,11 +25,9 @@
   ],
   "homepage": "https://github.com/snyk/snyk-paket-parser#readme",
   "dependencies": {
-    "lodash": "4.17.11",
     "tslib": "^1.9.3"
   },
   "devDependencies": {
-    "@types/lodash": "^4.14.116",
     "@types/node": "^4.0.47",
     "ts-node": "7.0.0",
     "tslint": "5.11.0",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Remove lodash because we use only `startsWith` which could be easily inlined in pure JS.