### PR TITLE
chore: update compiler options to support earlier version of node for cli

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,8 @@
   "compilerOptions": {
     "outDir": "./dist",
     "pretty": true,
-    "target": "es2017",
+    "lib": ["es2017", "es5", "es2015.promise"],
+    "target": "es5",
     "module": "commonjs",
     "sourceMap": true,
     "declaration": true,


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Compiler options only supported later version of es. cli needs to support node 4 and up
