### PR TITLE
fix: use base of dir as project name

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -61,7 +61,7 @@ export async function buildDepTreeFromFiles(
 
   return {
     dependencies: await buildDepTree(manifestFileContents, lockFileContents, includeDev, strict),
-    name: root,
+    name: path.basename(path.dirname(manifestFileFullPath)),
     version: '',
   } as DepTree;
 }

--- a/test/node4/index.js
+++ b/test/node4/index.js
@@ -15,8 +15,6 @@ const deepStrictEqual = require('assert').deepStrictEqual;
     'paket.lock',
     true)
     .then((tree) => {
-      tree.name = 'test';
-
       const outData = readFileSync(join(__dirname, '../tree/fixtures', fixtureName, 'out.json'), 'utf8');
       const expectedOut = JSON.parse(outData);
 

--- a/test/tree/fixtures/frequent-deps/out.json
+++ b/test/tree/fixtures/frequent-deps/out.json
@@ -632,6 +632,6 @@
       }
     }
   },
-  "name": "test",
+  "name": "frequent-deps",
   "version": ""
 }

--- a/test/tree/fixtures/out-of-sync/out.json
+++ b/test/tree/fixtures/out-of-sync/out.json
@@ -27,6 +27,6 @@
       "missingLockFileEntry": true
     }
   },
-  "name": "test",
+  "name": "out-of-sync",
   "version": ""
 }

--- a/test/tree/fixtures/simple/out.json
+++ b/test/tree/fixtures/simple/out.json
@@ -128,6 +128,6 @@
       "version": "3.0.1"
     }
   },
-  "name": "test",
+  "name": "simple",
   "version": ""
 }

--- a/test/tree/fixtures/with-test-dependencies/out-without-dev.json
+++ b/test/tree/fixtures/with-test-dependencies/out-without-dev.json
@@ -64,6 +64,6 @@
       "version": "5.8.4"
     }
   },
-  "name": "test",
+  "name": "with-test-dependencies",
   "version": ""
 }

--- a/test/tree/fixtures/with-test-dependencies/out.json
+++ b/test/tree/fixtures/with-test-dependencies/out.json
@@ -70,6 +70,6 @@
       "version": "3.11.0"
     }
   },
-  "name": "test",
+  "name": "with-test-dependencies",
   "version": ""
 }

--- a/test/tree/index.test.ts
+++ b/test/tree/index.test.ts
@@ -16,8 +16,6 @@ describe('dependencies parser', () => {
         true,
       );
 
-      tree.name = 'test';
-
       const outData = readFileSync(join(__dirname, 'fixtures', fixtureName, 'out.json'), 'utf8');
       const expectedOut = JSON.parse(outData);
 
@@ -32,8 +30,6 @@ describe('dependencies parser', () => {
       'paket.lock',
       false,
     );
-
-    tree.name = 'test';
 
     const outData = readFileSync(
       join(__dirname, 'fixtures', 'with-test-dependencies', 'out-without-dev.json'),
@@ -69,8 +65,6 @@ describe('dependencies parser', () => {
       false,
       false,
     );
-
-    tree.name = 'test';
 
     const outData = readFileSync(join(__dirname, 'fixtures', 'out-of-sync', 'out.json'), 'utf8');
     const expectedOut = JSON.parse(outData);


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
the name of the directory we want to set for the project is not necessarily the root, but the relative basename from the path to the manifest file.
